### PR TITLE
Dynamically downloading SPYFFIDATA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 
 install:
   - make -C test install
-  - make -C test SPyFFIdata/inputs
 
 script:
   - make -C test

--- a/CCD.py
+++ b/CCD.py
@@ -152,10 +152,11 @@ class CCD(object):
         self.header['CCDNOTE'] = ('', 'Details of this individual image')
         self.header['EXPTIME'] = (self.camera.cadence, '[s] exposure time ')
         self.header['NREADS'] = (
-        np.round(self.camera.cadence / self.camera.singleread).astype(np.int), '# of reads summed')
+            np.round(self.camera.cadence / self.camera.singleread).astype(np.int), '# of reads summed')
         self.header['SUBEXPTI'] = (self.camera.singleread, '[s] exposure in a single subexposure')
         self.header['SATURATE'] = (
-        self.camera.saturation * self.camera.cadence / self.camera.singleread, '[e-] saturation level in this image')
+            self.camera.saturation * self.camera.cadence / self.camera.singleread,
+            '[e-] saturation level in this image')
         self.header['READNOIS'] = (self.camera.read_noise, '[e-] read noise (per individual read)')
         self.header['READTIME'] = (self.camera.readouttime, '[s] time to transer to frame store')
         self.header['CCDNUM'] = (self.number, 'CCD number (1,2,3,4 or 0=fake subarray)')
@@ -517,7 +518,7 @@ class CCD(object):
       self.ax_prf.set_xlim(-self.psf.dx_pixels, self.psf.dy_pixels)
       self.ax_prf.set_ylim(-self.psf.dx_pixels, self.psf.dy_pixels)
       self.ax_prf.set_aspect(1)
-      self.ax_prf.figure.savefig(settings.prefix + 'plots/prnu_demo.pdf')
+      self.ax_prf.figure.savefig(os.path.join(settings.plots, 'prnu_demo.pdf'))
       plt.draw()'''
 
         ok = (xindex >= self.xmin) * (xindex < self.xsize) * (yindex >= self.ymin) * (yindex < self.ysize)
@@ -822,9 +823,9 @@ class CCD(object):
         """Add read noise to image."""
         logger.info("adding read noise")
         logger.info("    = quadrature sum of {2:.0f} reads with {3} e- each.".format(self.camera.cadence,
-                                                                                    self.camera.singleread,
-                                                                                    self.camera.cadence / self.camera.singleread,
-                                                                                    self.camera.read_noise))
+                                                                                     self.camera.singleread,
+                                                                                     self.camera.cadence / self.camera.singleread,
+                                                                                     self.camera.read_noise))
 
         # calculate the variance due to read noise
         noise_variance = self.camera.cadence / self.camera.singleread * self.camera.read_noise ** 2
@@ -844,7 +845,7 @@ class CCD(object):
         """Smear the image along the readout direction."""
         logger.info("adding readout smear")
         logger.info("    assuming {0} second readout times on {1} second exposures.".format(self.camera.readouttime,
-                                                                                           self.camera.singleread))
+                                                                                            self.camera.singleread))
 
         untouched = self.image + 0.0
         mean = np.mean(self.image, 0).reshape(1, self.image.shape[0]) * self.ones()
@@ -1046,7 +1047,7 @@ class Aberrator(object):
             if i == 1:
                 plt.xlabel('residuals')
 
-        plt.savefig(self.ccd.directory + 'aberrationgeometry.pdf')
+        plt.savefig(os.path.join(self.ccd.directory, 'aberrationgeometry.pdf'))
 
     def plotPossibilities(self, n=100):
         x, y = np.random.uniform(0, self.ccd.xsize, n), np.random.uniform(0, self.ccd.ysize, n)
@@ -1093,8 +1094,9 @@ class Aberrator(object):
         plt.axvline(27.4, color='gray', alpha=1)
         plt.xlim(-1 + min(bjds), max(bjds) + 1)
         plt.xlabel('Time (days)')
-        plt.savefig(self.ccd.directory + 'aberrationoveroneyear.pdf')
-        logger.info('saved a plot of the aberration over one year to {}'.format(self.ccd.directory))
+        path = os.path.join(self.ccd.directory, 'aberrationoveroneyear.pdf')
+        plt.savefig(path)
+        logger.info('saved a plot of the aberration over one year to {}'.format(path))
 
 
 def gauss(x, y, xcenter, ycenter):

--- a/CCD.py
+++ b/CCD.py
@@ -126,7 +126,7 @@ class CCD(object):
     @property
     def directory(self):
         """Directory for saving all images from this CCD."""
-        d = self.camera.directory + self.name + '/'
+        d = os.path.join(self.camera.directory, self.name)
         zachopy.utils.mkdir(d)
         return d
 
@@ -296,7 +296,7 @@ class CCD(object):
 
         # make filename for this image
         self.note = 'simulated_' + self.fileidentifier
-        finalfilename = self.directory + self.note + '.fits' + zipsuffix
+        finalfilename = os.path.join(self.directory, self.note + '.fits' + zipsuffix)
 
         # write the image to FITS
         logger.info('saving simulated exposure {} for {}'.format(
@@ -306,7 +306,7 @@ class CCD(object):
         # optionally, write some other outputs too!
         if lean == False:
             self.note = 'withoutbackground_{0:06.0f}'.format(self.camera.counter)
-            self.writeToFITS(self.image - self.backgroundimage, self.directory + self.note + '.fits')
+            self.writeToFITS(self.image - self.backgroundimage, os.path.join(self.directory, self.note + '.fits'))
 
     def stampify(self):
         if self.stamps is not None:
@@ -358,16 +358,19 @@ class CCD(object):
     def writeIngredients(self):
 
         # write the catalog out to a text file
-        outfile = self.directory + 'catalog_{pos}_{name}_atepoch{epoch:.3f}.txt'.format(pos=self.pos_string,
-                                                                                        name=self.name,
-                                                                                        epoch=self.epoch)
+        outfile = os.path.join(self.directory,
+                               'catalog_{pos}_{name}_atepoch{epoch:.3f}.txt'.format(pos=self.pos_string,
+                                                                                    name=self.name,
+                                                                                    epoch=self.epoch))
         self.camera.catalog.writeProjected(ccd=self, outfile=outfile)
 
-        jitteroutfile = self.directory + 'jitternudges_{cadence:.0f}s_{name}.txt'.format(cadence=self.camera.cadence,
-                                                                                         name=self.name)
+        jitteroutfile = os.path.join(
+            self.directory, 'jitternudges_{cadence:.0f}s_{name}.txt'.format(cadence=self.camera.cadence,
+                                                                            name=self.name))
         self.camera.jitter.writeNudges(jitteroutfile)
 
-        focusoutfile = self.directory + 'focustimeseries_{name}.txt'.format(name=self.name)
+        focusoutfile = os.path.join(
+            self.directory, 'focustimeseries_{name}.txt'.format(name=self.name))
         self.camera.focus.writeModel(focusoutfile)
 
     def projectCatalog(self, write=True):
@@ -540,7 +543,7 @@ class CCD(object):
         try:
             assert (remake == False)
             self.note = 'starsbrighterthan{0}'.format(np.max(magnitude_thresholds))
-            starsfilename = self.directory + self.note + '.fits'
+            starsfilename = os.path.join(self.directory, self.note + '.fits')
             try:
                 self.starimage
             except:
@@ -559,7 +562,7 @@ class CCD(object):
 
                 # define a filename for this magnitude range
                 self.note = 'starsbrighterthan{0:02d}'.format(magnitudethreshold)
-                starsfilename = self.directory + self.note + '.fits'
+                starsfilename = os.path.join(self.directory, self.note + '.fits')
 
                 # load the existing stellar image, if possible
                 try:
@@ -643,7 +646,7 @@ class CCD(object):
         # (optionally), write cosmic ray image
         if write:
             self.note = 'cosmics_' + self.fileidentifier
-            cosmicsfilename = self.directory + self.note + '.fits' + zipsuffix
+            cosmicsfilename = os.path.join(self.directory, self.note + '.fits' + zipsuffix)
             self.writeToFITS(image, cosmicsfilename)
 
         # add the cosmics into the running image
@@ -746,7 +749,7 @@ class CCD(object):
             stilloversaturated = (self.image > saturation_limit).any() and count < 10
 
         self.note = 'saturation_{0}K'.format(self.camera.saturation).replace('.', 'p')
-        saturationfilename = self.directory + self.note + '.fits'
+        saturationfilename = os.path.join(self.directory, self.note + '.fits')
         if not os.path.exists(saturationfilename):
             self.writeToFITS(self.image - untouched, saturationfilename)
 
@@ -759,7 +762,7 @@ class CCD(object):
 
         # set up filenames for saving background, if need be
         self.note = 'backgrounds'
-        backgroundsfilename = self.directory + self.note + '.fits'
+        backgroundsfilename = os.path.join(self.directory, self.note + '.fits')
         logger.info("adding backgrounds")
 
         # if the background image already exists, just load it
@@ -813,7 +816,7 @@ class CCD(object):
         self.noiseimage = noise
 
         self.note = 'photonnoise'
-        noisefilename = self.directory + self.note + '.fits'
+        noisefilename = os.path.join(self.directory, self.note + '.fits')
         if not os.path.exists(noisefilename):
             self.writeToFITS(noise, noisefilename)
         self.addInputLabels()
@@ -852,7 +855,7 @@ class CCD(object):
         self.image += mean * self.camera.readouttime / self.camera.singleread
 
         self.note = 'readoutsmear'
-        smearfilename = self.directory + self.note + '.fits'
+        smearfilename = os.path.join(self.directory, self.note + '.fits')
         if not os.path.exists(smearfilename):
             self.writeToFITS(self.image - untouched, smearfilename)
 
@@ -915,7 +918,7 @@ class CCD(object):
         if writenoiseless:
             # make filename for this image
             self.note = 'noiseless_' + self.fileidentifier
-            noiselessfilename = self.directory + self.note + '.fits' + zipsuffix
+            noiselessfilename = os.path.join(self.directory, self.note + '.fits' + zipsuffix)
 
             # write the image to FITS
             logger.info('saving noiseless TESS image')

--- a/Camera.py
+++ b/Camera.py
@@ -152,7 +152,7 @@ class Camera(object):
 
     @property
     def directory(self):
-        d = self.fielddirectory + '{0:d}s/'.format(self.cadence)
+        d = os.path.join(self.fielddirectory, '{0:d}s/'.format(self.cadence))
         zachopy.utils.mkdir(d)
         return d
 

--- a/Camera.py
+++ b/Camera.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import numpy as np
 import zachopy.utils
@@ -46,7 +47,7 @@ class Camera(object):
 
         # in case you want everything stored in its own directory
         self.dirprefix = dirprefix
-        zachopy.utils.mkdir(settings.prefix + 'outputs/{}'.format(self.dirprefix))
+        zachopy.utils.mkdir(os.path.join(settings.outputs, self.dirprefix))
 
         # KLUDGE (or is it?)
         self.stamps = stamps
@@ -70,7 +71,7 @@ class Camera(object):
         self.warpspaceandtime = warpspaceandtime
         if self.warpspaceandtime:
             logger.info('the camera will warp space and time by slowing '
-                       'the speed of light to {}c'.format(self.warpspaceandtime))
+                        'the speed of light to {}c'.format(self.warpspaceandtime))
 
         # should positions be aberrated?
         self.aberrate = aberrate
@@ -82,7 +83,7 @@ class Camera(object):
         self.counterstep = counterstep
         if self.counterstep > 1:
             logger.info('the camera will speed up time'
-                       ' by a factor of {}'.format(self.counterstep))
+                        ' by a factor of {}'.format(self.counterstep))
 
 
         # if real stars, use the input (ra, dec)
@@ -139,10 +140,13 @@ class Camera(object):
     def fielddirectory(self):
         """define the field directory for this camera"""
         if self.label == '':
-            d = settings.prefix + 'outputs/{dirprefix}{pos}/'.format(pos=self.pos_string(), dirprefix=self.dirprefix)
+            d = os.path.join(settings.outputs,
+                             '{dirprefix}{pos}'.format(pos=self.pos_string(), dirprefix=self.dirprefix))
         else:
-            d = settings.prefix + 'outputs/{dirprefix}{pos}_{label}/'.format(pos=self.pos_string(), label=self.label,
-                                                                             dirprefix=self.dirprefix)
+            d = os.path.join(settings.outputs,
+                             '{dirprefix}{pos}_{label}'.format(pos=self.pos_string(),
+                                                               label=self.label,
+                                                               dirprefix=self.dirprefix))
         zachopy.utils.mkdir(d)
         return d
 

--- a/Jitter.py
+++ b/Jitter.py
@@ -39,7 +39,7 @@ def makeCartoon(seed=1):
         d[k] = v / np.std(v) * rmsat2s1d
 
     table = astropy.table.Table(d, names=['t', 'x', 'y'])
-    table.write(settings.inputs + 'cartoon.jitter', format='ascii.fixed_width', bookend=False)
+    table.write(os.path.join(settings.inputs, 'cartoon.jitter'), format='ascii.fixed_width', bookend=False)
 
 
 class Jitter(object):
@@ -56,7 +56,7 @@ class Jitter(object):
 
         # set up the initial raw jitter file
         # (this one cam from Roland, some time ago)
-        self.rawfile = settings.prefix + "inputs/" + rawjitterbasename
+        self.rawfile = os.path.join(settings.inputs, rawjitterbasename)
 
         # what do you want the RMS to be rescaled to?
         self.jitterrms = jitterrms
@@ -111,7 +111,7 @@ class Jitter(object):
         zachopy.utils.mkdir(directory)
 
         # define the filename
-        return directory + self.basename + '.processed.npy'
+        return os.path.join(directory, self.basename + '.processed.npy')
 
     def loadProcessedJitterball(self):
         """load a pre-processed jitterball, from the intermediates directory"""
@@ -190,7 +190,7 @@ class Jitter(object):
 
 
         # create the plot of the timeseries
-        plotdirectory = settings.plots + self.directory
+        plotdirectory = os.path.join(settings.plots, self.directory)
         zachopy.utils.mkdir(plotdirectory)
         bkw = dict(alpha=0.5, color='black')
         rkw = dict(linewidth=2, alpha=0.5, marker='o', color='red')
@@ -205,7 +205,8 @@ class Jitter(object):
         ax[0].set_ylabel('x (")')
         ax[1].set_ylabel('y (")')
         ax[1].set_xlabel('Time (seconds)')
-        fi.savefig(plotdirectory + self.basename + '_timeseries.pdf')
+        fi.savefig(os.path.join(plotdirectory,
+                                self.basename + '_timeseries.pdf'))
 
         # make interpolators to keep track of the running smooth means
         ikw = dict(kind='nearest', fill_value=0, bounds_error=False)
@@ -241,7 +242,7 @@ class Jitter(object):
                    title='TESS Pointing Jitter over {0}s'.format(
                        self.camera.cadence),
                    xtitle='Pixels', ytitle='Pixels',
-                   filename=plotdirectory + self.basename + '_jittermap.pdf')
+                   filename=os.path.join(plotdirectory, self.basename + '_jittermap.pdf'))
 
         # save the necessary jitter files
         logger.info('saving the jitter files to {0}'.format(self.processedfile))

--- a/Observation.py
+++ b/Observation.py
@@ -3,6 +3,7 @@ of any size
 of any cadence
 of any length
 of either the sky or a test pattern."""
+import os
 
 import Camera
 import Catalogs
@@ -61,7 +62,7 @@ class Observation(object):
         for k in self.cadencestodo.keys():
             # set the cadence to this one
             self.camera.setCadence(k)
-            np.save(self.camera.directory + 'observationdictionary.npy', self.inputs)
+            np.save(os.path.join(self.camera.directory, 'observationdictionary.npy'), self.inputs)
             # reset the counter
             self.camera.counter = 0
 

--- a/PSF.py
+++ b/PSF.py
@@ -30,7 +30,6 @@ class PSF(object):
                  nsubpixelsperpixel=101, npixels=21,
                  npositions_toinclude=21, noffsets_toinclude=11):
 
-
         # link this PSF to a Camera (hopefully one with a Cartographer)
         self.setCamera(camera)
 
@@ -71,16 +70,17 @@ class PSF(object):
     @property
     def deblibrarydirectory(self):
         f = '{:.0f}'.format
-        d = self.versiondirectory + 'focus{}_stellartemp{}/'.format(
-            'and'.join(map(f, self.focus_toinclude)),
-            'and'.join(map(f, self.stellartemp_toinclude)))
+        d = os.path.join(self.versiondirectory,
+                         'focus{}_stellartemp{}/'.format(
+                             'and'.join(map(f, self.focus_toinclude)),
+                             'and'.join(map(f, self.stellartemp_toinclude))))
         zachopy.utils.mkdir(d)
         return d
 
     def populateUnjitteredPSFLibrary(self):
         """populate (from scratch), a library of Deb's PRFs"""
 
-        filename = self.deblibrarydirectory + 'originaldeblibrary.npy'
+        filename = os.path.join(self.deblibrarydirectory, 'originaldeblibrary.npy')
         try:
             self.psflibrary = np.load(filename)[0]
             logger.info('loaded original Deb library from {0}'.format(filename))
@@ -210,7 +210,7 @@ class PSF(object):
 
     @property
     def quickloadingdirectory(self):
-        d = self.versiondirectory + 'scratch/'
+        d = os.path.join(self.versiondirectory, 'scratch')
         zachopy.utils.mkdir(d)
         return d
 
@@ -220,8 +220,10 @@ class PSF(object):
 
         logger.info('loading PSF from {}'.format(debfile))
 
-        quicksummaryfilename = self.quickloadingdirectory + os.path.basename(debfile) + '.summary.npy'
-        quickPSFfilename = self.quickloadingdirectory + os.path.basename(debfile) + '.PSF.npy'
+        quicksummaryfilename = os.path.join(self.quickloadingdirectory,
+                                            os.path.basename(debfile) + '.summary.npy')
+        quickPSFfilename = os.path.join(self.quickloadingdirectory,
+                                        os.path.basename(debfile) + '.PSF.npy')
         try:
             logger.info('trying to load quickfile from {}'.format(quickPSFfilename))
             stellartemps, focuss, fieldxs, fieldys = np.load(quicksummaryfilename)
@@ -339,21 +341,21 @@ class PSF(object):
     @property
     def basedirectory(self):
         """the directory in which all processed PSF data will be stored"""
-        d = settings.intermediates + 'psfs/'
+        d = os.path.join(settings.intermediates, 'psfs')
         zachopy.utils.mkdir(d)
         return d
 
     @property
     def versiondirectory(self):
         """the directory for this particular version of the PSFs"""
-        d = self.basedirectory + self.version + '/'
+        d = os.path.join(self.basedirectory, self.version)
         zachopy.utils.mkdir(d)
         return d
 
     @property
     def plotdirectory(self):
         """the directory where plots should be stored"""
-        d = self.versiondirectory + 'plots/'
+        d = os.path.join(self.versiondirectory, 'plots')
         zachopy.utils.mkdir(d)
         return d
 
@@ -382,7 +384,8 @@ class PSF(object):
     def populateJitteredPSFLibrary(self):
         """convolve Deb's PSFs with a jittermap, at the camera's cadence"""
         logger.info('populating the jittered PSF library')
-        jitteredfilename = self.deblibrarydirectory + 'jitteredlibrary_{}.npy'.format(self.camera.jitter.basename)
+        jitteredfilename = os.path.join(
+            self.deblibrarydirectory, 'jitteredlibrary_{}.npy'.format(self.camera.jitter.basename))
 
         try:
             self.psflibrary
@@ -761,10 +764,12 @@ class PSF(object):
 
         self.setupPixelArrays()
 
-        binned_filename = self.deblibrarydirectory + 'pixelizedlibrary_{jitter}_{intrapixel}_{npositions:02.0f}positions_{noffsets:02.0f}offsets.npy'.format(
-            jitter=self.camera.jitter.basename, intrapixel=self.intrapixel.name,
-            npositions=self.npositions, noffsets=self.noffsets
-        )
+        binned_filename = \
+            os.path.join(self.deblibrarydirectory,
+                         'pixelizedlibrary_{jitter}_{intrapixel}_'
+                         '{npositions:02.0f}positions_{noffsets:02.0f}offsets.npy'.format(
+                             jitter=self.camera.jitter.basename, intrapixel=self.intrapixel.name,
+                             npositions=self.npositions, noffsets=self.noffsets))
         try:
             logger.info('trying to load PSFs from {0}'.format(binned_filename))
             self.binned, self.binned_axes = np.load(binned_filename)

--- a/PSF.py
+++ b/PSF.py
@@ -62,7 +62,8 @@ class PSF(object):
         self.debfiles = []
         for focus in self.focus_toinclude:
             self.debfiles.extend(
-                glob.glob(settings.inputs + self.debprefix + '_hx*_hy*_foc{:.0f}umPRFs.mat'.format(focus)))
+                glob.glob(os.path.join(settings.inputs,
+                                       self.debprefix + '_hx*_hy*_foc{:.0f}umPRFs.mat'.format(focus))))
         logger.info(
             'there are {} files from Deb, spanning focus of {}'.format(len(self.debfiles), self.focus_toinclude))
         assert (len(self.debfiles) > 0)

--- a/Stamper.py
+++ b/Stamper.py
@@ -1,3 +1,4 @@
+import os
 import Catalogs
 import numpy as np
 import astropy
@@ -45,8 +46,9 @@ class Stamper(object):
         t = astropy.table.Table([self.ra, self.dec, self.radii], names=('ra', 'dec', 'radius'))
 
         # write it out
-        f = self.ccd.directory + 'postagestamptargets_{pos}_{name}.txt'.format(pos=self.ccd.pos_string,
-                                                                               name=self.ccd.name)
+        f = os.path.join(
+            self.ccd.directory, 'postagestamptargets_{pos}_{name}.txt'.format(pos=self.ccd.pos_string,
+                                                                              name=self.ccd.name))
 
         t.write(f, format='ascii.fixed_width', delimiter='|', bookend=False)
         logger.info('wrote stamp definition catalog to {}'.format(f))
@@ -79,8 +81,9 @@ class Stamper(object):
 
         # weight stars inversely to their abundance, to give roughly uniform distribution of magnitudes
         weights = \
-        (1.0 / dndmag(self.camera.catalog.tmag) * (self.camera.catalog.tmag >= 6) * (self.camera.catalog.tmag <= 16))[
-            onccd]
+            (1.0 / dndmag(self.camera.catalog.tmag) * (self.camera.catalog.tmag >= 6) * (
+            self.camera.catalog.tmag <= 16))[
+                onccd]
         weights /= np.sum(weights)
         itargets = np.random.choice(onccd.nonzero()[0],
                                     size=np.minimum(nstamps, np.sum(weights != 0)),
@@ -163,5 +166,5 @@ class Stamper(object):
 
         self.ccd.stampimage = mask
         self.ccd.note = 'stampdefinition'
-        stampfilename = self.ccd.directory + self.ccd.note + '.fits'
+        stampfilename = os.path.join(self.ccd.directory, self.ccd.note + '.fits')
         self.ccd.writeToFITS(self.ccd.stampimage, stampfilename)

--- a/relations.py
+++ b/relations.py
@@ -1,4 +1,5 @@
 '''Handy relations, mostly interpolations out of paper tables.'''
+import os
 import settings
 import astropy.io.ascii
 import scipy.interpolate
@@ -8,7 +9,7 @@ import numpy.polynomial.polynomial as polynomial
 
 # convert colors, using the Sloan stellar locus
 def davenport(color, input='r-J', output='r-i'):
-    data = astropy.io.ascii.read(settings.prefix + 'inputs/davenport_table1.txt',
+    data = astropy.io.ascii.read(os.path.join(settings.inputs, 'davenport_table1.txt'),
                                  names=['g-i', '#', 'u-g', 'eu-g', 'g-r', 'eg-r', 'r-i', 'er-i', 'i-z', 'ei-z', 'z-J',
                                         'ez-J', 'J-H', 'eJ-H', 'H-K', 'eH-K'])
     if input == 'r-J':
@@ -27,7 +28,7 @@ def davenport(color, input='r-J', output='r-i'):
 # spit out the Pickles temperature associated with an input color
 def pickles(color, input='R-J'):
     # assuming
-    data = astropy.io.ascii.read(settings.prefix + 'inputs/pickles_table2.txt')
+    data = astropy.io.ascii.read(os.path.join(settings.inputs, 'pickles_table2.txt'))
     ok = data['[Fe/H]'] == 0
     if input == 'R-J':
         x = data['V-J'][ok] - data['V-R'][ok]

--- a/settings.py
+++ b/settings.py
@@ -11,7 +11,7 @@ from sh import wget, tar, rm, shasum
 # if those directories don't contain the required input data, it will complain!
 
 # load the environment variable
-prefix = os.getenv('SPYFFIDATA', os.path.expanduser("~/.tess/spyffi/"))
+prefix = os.path.expanduser(os.getenv('SPYFFIDATA', "~/.tess/spyffi"))
 if not os.path.exists(prefix):
     os.makedirs(prefix)
 

--- a/settings.py
+++ b/settings.py
@@ -11,7 +11,7 @@ from sh import wget, tar, rm, shasum
 # if those directories don't contain the required input data, it will complain!
 
 # load the environment variable
-prefix = os.getenv('SPYFFIDATA', os.path.expanduser("~/.tess/spyffi"))
+prefix = os.getenv('SPYFFIDATA', os.path.expanduser("~/.tess/spyffi/"))
 if not os.path.exists(prefix):
     os.makedirs(prefix)
 

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,8 @@
 """Global settings required needed for TESS SPyFFI simulations."""
 import os
 import logging
+# noinspection PyUnresolvedReferences
+from sh import wget, tar, rm, shasum
 
 # okay, so, we need to specify where all the SPyFFI data will be
 # this will...
@@ -13,22 +15,69 @@ prefix = os.getenv('SPYFFIDATA', os.path.expanduser("~/.tess/spyffi"))
 if not os.path.exists(prefix):
     os.makedirs(prefix)
 
-
 logging.basicConfig(
     format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
     datefmt="%H:%M:%S",
     level=getattr(logging, os.getenv('LOG', 'WARNING').upper()))
 
 log_file_handler = logging.FileHandler(os.getenv('LOG_FILE', os.path.join(prefix, 'SPyFFI.log')))
+logger = logging.getLogger(__name__)
+logger.addHandler(log_file_handler)
 
 # create dirs that will store inputs and outputs
-dirs = {'plots': os.path.join(prefix, 'plots/'), 'inputs': os.path.join(prefix, 'inputs/'),
-        'outputs': os.path.join(prefix, 'outputs/'), 'intermediates': os.path.join(prefix, 'intermediates/')}
+dirs = {'plots': os.path.join(prefix, 'plots/'),
+        'inputs': os.path.join(prefix, 'inputs/'),
+        'outputs': os.path.join(prefix, 'outputs/'),
+        'intermediates': os.path.join(prefix, 'intermediates/')}
 
-# make sure all those directories exist
-for d in dirs.values():
-    if not os.path.exists(d):
-        os.makedirs(d)
+# TODO: https://github.com/TESScience/SPyFFI/issues/18
+checksums = \
+    """
+994ddb7fb44efd7963730d29051378e0c79861ccd5a93de0bb46cfe34d2b8b8f  ./inputs/AttErrTimeArcsec_80k.dat
+454a4219d5d97b53416754c54e37a7e98c071dab09ab1151084ab1d1f0891d95  ./inputs/cartoon.jitter
+dc518dd3c58f01f1a723b21ed3ce56bb48b56ae8a99614024a8db5535e3809a4  ./inputs/covey_pickles.txt
+494d685fce7d322f9c310f9995207d8977e84a7cfcf0dcab444ba62455980819  ./inputs/davenport_table1.txt
+a659f51a89b84b2cb194e83984936fc63f83e7d52f1ff9f3317321a5021e6478  ./inputs/pickles_table2.txt
+6cf1fbbff6b604471a947039bc0d7f56b06c69cd234c91cc72bd989225d359bb  ./intermediates/psfs/RRUasbuilt/focus0and10_stellartemp4350/originaldeblibrary.npy
+dbdac6e3268267eb286fb49fbccec3d4ba0e34c6a611ea18de4d54961f910cdd  ./intermediates/psfs/RRUasbuilt/focus0and10_stellartemp4350/pixelizedlibrary_cartoon.jitter.cadence120s.unscaled_perfectpixels_11positions_11offsets.npy
+dbdac6e3268267eb286fb49fbccec3d4ba0e34c6a611ea18de4d54961f910cdd  ./intermediates/psfs/RRUasbuilt/focus0and10_stellartemp4350/pixelizedlibrary_cartoon.jitter.cadence1800s.unscaled_perfectpixels_11positions_11offsets.npy
+dbdac6e3268267eb286fb49fbccec3d4ba0e34c6a611ea18de4d54961f910cdd  ./intermediates/psfs/RRUasbuilt/focus0and10_stellartemp4350/pixelizedlibrary_cartoon.jitter.cadence2s.unscaled_perfectpixels_11positions_11offsets.npy
+"""
+data_url = "https://www.dropbox.com/s/0e4c2uk34phv4qx/SPyFFI_coreinputs.tar.gz"
+
+
+def initialize():
+    # noinspection PyUnresolvedReferences
+    from sh import wget, tar, rm, shasum
+    if not os.path.exists(prefix):
+        os.makedirs(prefix)
+
+    if (not os.path.exists(dirs['inputs'])) or (not os.path.exists(dirs['intermediates'])):
+        try:
+            if not os.path.exists(prefix):
+                logger.info("Creating {DIR}".format(DIR=prefix))
+                os.makedirs(prefix)
+            logger.info("Downloading data from {URL} to {DIR}".format(URL=data_url, DIR=prefix))
+            tar(wget(data_url, "-qO-", _piped=True), "xz", _cwd=prefix)
+            logger.info("Checking checksums of downloaded files")
+            for line in shasum("-c", _cwd=prefix, _in=checksums, _iter=True):
+                logger.info(line)
+        except Exception as e:
+            logger.info("Error: {}".format(e.message))
+            logger.info("Deleting {DIR}".format(DIR=dirs['inputs']))
+            rm(dirs['inputs'], '-rf')
+            logger.info("Deleting {DIR}".format(DIR=dirs['intermediates']))
+            rm(dirs['intermediates'], '-rf')
+            raise
+
+    # make sure all those directories exist
+    for d in (dirs['outputs'], dirs['plots']):
+        if not os.path.exists(d):
+            logger.info("Creating {DIR}".format(DIR=d))
+            os.makedirs(d)
+
+
+initialize()
 
 # shortcuts
 plots = dirs['plots']

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author='Zach Berta-Thompson',
     author_email='zkbt@mit.edu',
     url='https://github.com/TESScience/SPyFFI',
-    install_requires=['zachopy', 'matplotlib', 'numpy', 'astropy==1.1.2', 'astroquery'],
+    install_requires=['zachopy', 'matplotlib', 'numpy', 'astropy==1.1.2', 'astroquery', 'sh'],
     ext_modules=[Extension("SPyFFI.cosmical_realistic._cosmical",
                            ["cosmical_realistic/_cosmical.c",
                             "cosmical_realistic/cosmical.c",

--- a/test/Makefile
+++ b/test/Makefile
@@ -70,11 +70,7 @@ uninstall: $(INSTALL)
 
 light_curve_tests: light_curve_draw_rotation_test light_curve_draw_transit_test
 
-SPyFFIdata/inputs:
-	mkdir -p $(dir $@)
-	wget -qO- https://www.dropbox.com/s/0e4c2uk34phv4qx/SPyFFI_coreinputs.tar.gz | tar xzv -C $(dir $@)
-
-$(TEST_OUT): SPyFFIdata/inputs $(INSTALL)
+$(TEST_OUT): $(INSTALL)
 	# SPYFFIDATA: The directory where you want to store TESS data (inputs/intermediates/outputs)
 	LOG=INFO SPYFFIDATA=$(CURDIR)/SPyFFIdata/ $(PYTHON) ./scripts/smallone.py
 
@@ -82,7 +78,7 @@ light_curve_%_test: light_curve_%.json
 	./scripts/json_diff $< reference/$<
 
 light_curve_%.json: ./scripts/light_curve_%.py $(INSTALL)
-	LOG=INFO $(PYTHON) $< > $@
+	LOG=INFO SPYFFIDATA=$(CURDIR)/SPyFFIdata/ $(PYTHON) $< > $@
 
 clear-tests:
 	rm -rf SPyFFIdata/outputs *.out


### PR DESCRIPTION
This branch closes #14

You should now be able to install and run spyffi via:

``` bash
# cd /tmp # or where-ever
# virtualenv venv
# ./venv/bin/pip install -U pip setuptools ipython numpy
# ./venv/bin/pip install git+https://github.com/TESScience/SPyFFI.git@dynamic_download
# LOG=INFO ./venv/bin/ipython
```

This will set the default value for `SPYFFIDATA` to `~/.tess/spyffi` and download input and intermediate files as necessary.
