### PR TITLE
Fix numpy requirement for building using setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 from setuptools import setup, Extension
-import numpy.distutils.misc_util
+from setuptools.command.build_ext import build_ext
 
 VERSION = '1.0.0'
+
+class numpy_build_options(build_ext):
+    """We can't important numpy directly because it's not ready yet."""
+    def finalize_options(self):
+        build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+
 
 setup(
     name='SPyFFI',
@@ -22,14 +32,16 @@ setup(
     author='Zach Berta-Thompson',
     author_email='zkbt@mit.edu',
     url='https://github.com/TESScience/SPyFFI',
+    setup_requires=['numpy'],
     install_requires=['zachopy', 'matplotlib', 'numpy', 'astropy==1.1.2', 'astroquery'],
+    cmdclass={'build_ext':numpy_build_options},
     ext_modules=[Extension("SPyFFI.cosmical_realistic._cosmical",
                            ["cosmical_realistic/_cosmical.c",
                             "cosmical_realistic/cosmical.c",
                             "cosmical_realistic/twister.c",
                             "cosmical_realistic/seed_tw_ran.c",
 			    "cosmical_realistic/fmemopen.c"],
-                           include_dirs=numpy.distutils.misc_util.get_numpy_include_dirs())],
+                          )],
     # Uncomment this if there's a tagged release that's the same as VERSION, and SPyFFI is publicly released
     download_url = 'https://github.com/TESScience/SPyFFI/tarball/{}'.format(VERSION),
 )


### PR DESCRIPTION
These changes are needed to build on a blank Ubuntu 16.04 machine, installing python-dev and libfreetype6-dev into a virtualenv using python 2.7.

Without these changes numpy is missing from the requirements and the package doesn't build and install. (even doing ./setup.py --help would fail here)
